### PR TITLE
Append goal notion to psu values, value is too blury

### DIFF
--- a/api/api_psu.md
+++ b/api/api_psu.md
@@ -25,9 +25,10 @@ Each value is represented in volts.
 
 | Field name |                  Description                   |  Type   | Read-only |
 | :--------- | :--------------------------------------------: | :-----: | :-------: |
-| value      |                 voltage value                  |  Float  |   False   |
-| min        |        minimal voltage value supported         |  Float  |   True    |
-| max        |        maximal voltage value supported         |  Float  |   True    |
+| real       |             current voltage value              |  Float  |   True    |
+| goal       |               voltage goal value               |  Float  |   False   |
+| min        |         minimal voltage goal supported         |  Float  |   True    |
+| max        |         maximal voltage goal supported         |  Float  |   True    |
 | decimals   | number of decimals supported for voltage value | Integer |   True    |
 
 ### Amps
@@ -36,9 +37,10 @@ Each value is represented in amperes.
 
 | Field name |                   Description                   |  Type   | Read-only |
 | :--------- | :---------------------------------------------: | :-----: | :-------: |
-| value      |                 amperage value                  |  Float  |   False   |
-| min        |        minimal amperage value supported         |  Float  |   True    |
-| max        |        maximal amperage value supported         |  Float  |   True    |
+| real       |             current amperage value              |  Float  |   True    |
+| goal       |               amperage goal value               |  Float  |   False   |
+| min        |         minimal amperage goal supported         |  Float  |   True    |
+| max        |         maximal amperage goal supported         |  Float  |   True    |
 | decimals   | number of decimals supported for amperage value | Integer |   True    |
 
 ### Settings


### PR DESCRIPTION
Salut,
J'ai transformé le champs value de volts et amps. Tout cela parce qu'on confond 2 concepts:

- la valeur objectif
- la valeur instantanée

les alimentations sont capables de remonter les 2 valeurs.

Du coup j'ai transformé "value" en "goal" et "real".

Notre ancien champs "value" devient "goal" et j'ajoute "real" pour la consommation courante (j'ai pas mis "current" pour ne pas confondre avec le courant électrique)

Min et max se réfère maintenant au goal uniquement
